### PR TITLE
Add DeployCo targeted FDE resume

### DIFF
--- a/deployco-forward-deployed-engineer.md
+++ b/deployco-forward-deployed-engineer.md
@@ -1,0 +1,86 @@
+# Tim Kersey
+## Principal Forward-Deployed / Agentic Systems Engineer
+
+[github.com/tkersey](https://github.com/tkersey)  
+[linkedin.com/in/timkersey](https://www.linkedin.com/in/timkersey)
+
+### Summary
+
+Principal agentic systems engineer and engineering leader focused on high-stakes customer deployments, production AI workflows, and ambiguous 0→1 product environments. Architected retrieval-augmented assistant systems for estate-planning workflow automation, built prompt optimization systems for AI-powered content generation, and led engineering teams from rapid prototype through production deployment under tight constraints.
+
+Strongest at operating as a player-coach: translating complex customer environments into clear technical direction, writing and reviewing production-grade software, making disciplined standardization-versus-customization decisions, and codifying successful delivery patterns into reusable tools, practices, and team feedback loops.
+
+### DeployCo Fit
+
+- Technical lead for ambiguous customer engagements across applied AI, workflow automation, regulated-domain delivery, marketplace products, streaming media, and enterprise transformation.
+- Production AI experience spanning retrieval-augmented generation, agentic assistants, prompt optimization, product feedback loops, and workflow automation.
+- 0→1 delivery pattern: discover the real customer problem, prototype quickly, identify reusable primitives, and deploy production-quality systems without over-fitting to one-off requests.
+- Player-coach leadership across consulting and client teams, with experience mentoring engineers, coordinating across product/design/engineering stakeholders, and raising delivery quality through clarity rather than process overhead.
+- Large-scale marketplace and commerce context including eBay experience, Grailed marketplace product discovery, and commerce operations systems at Gray's.
+<!-- TODO before submission: expand the eBay line with exact role/client context, dates, team size, stack, customer problem, and measurable outcome. -->
+
+### Core Expertise
+
+Agentic systems architecture • Forward-deployed engineering • Customer technical discovery • Retrieval-augmented generation • Tool-using AI workflows • Prompt optimization • Human-in-the-loop workflow automation • Production prototyping • Evals and quality loops • Technical leadership • Product discovery • Software architecture • Functional programming • Structured concurrency • Team mentoring
+
+### Technologies
+
+Python • JavaScript/TypeScript • Node.js • React • Java • Docker • Swift • SwiftUI • Structured Concurrency • RAG pipelines • LLM application architecture • SaaS integrations • Microservices • Regulated-domain integrations
+
+## Experience
+
+### [Artium](https://artium.ai) — Director of Engineering / Principal Software Engineer
+June 2021–Present
+
+Led engineering teams and client engagements building production software systems across applied AI, workflow automation, streaming media, enterprise transformation, and marketplace products. Operated as principal architect, technical lead, and delivery lead across ambiguous customer environments.
+
+- Architected retrieval-augmented AI assistant system for estate-planning workflow automation, translating domain-specific business processes into production assistant behavior.
+- Led engineering team through rapid prototyping and deployment of agentic assistants under tight delivery constraints.
+- Built prompt optimization framework for AI-powered rap lyric generation, creating measurable quality improvements for generated content workflows.
+- Guided product and engineering teams through discovery, architecture, implementation, and iteration for AI-enabled product experiences.
+- Led cross-functional product discovery for marketplace features, establishing rapid customer feedback loops and refining product direction under uncertainty.
+- Architected modular streaming platform patterns enabling rapid deployment of multiple product variants, including Apple Vision Pro launch work with pre-release hardware access.
+- Established production engineering patterns for reliability, maintainability, type safety, structured concurrency, and modular integration boundaries.
+- Mentored engineers and client teams on advanced software architecture, AI-assisted product development, and production delivery practices.
+
+### [Carbon Five](https://www.carbonfive.com) — Senior Software Developer
+February 2018–June 2021
+
+Served as senior engineer and technical lead across healthcare, fintech, banking, and SaaS client engagements, working as both individual contributor and team lead depending on engagement needs.
+
+- Co-led team of 12+ engineers to launch a HIPAA-compliant US healthcare platform with EHR integration, localization, microservices coordination, and mobile delivery.
+- Delivered HIPAA-compliant remote group therapy applications within an 8-week deadline using SaaS integrations and regulated-domain delivery practices.
+- Led teams through architecture selection, rapid product validation, and production delivery in ambiguous client environments.
+- Established engineering patterns for maintainable, scalable product systems across mobile, backend, and integration-heavy workflows.
+- Led adoption of protocol-oriented and reactive architecture patterns to scale a banking product for growth.
+
+### [Skurt](https://skurt.com) — Senior Software Engineer
+May 2017–January 2018
+
+Technical lead for a customer-facing on-demand rental car delivery product.
+
+- Led transition to test-driven development with incremental feature delivery, achieving full test coverage on new features.
+- Executed product transition from reservations to on-demand rentals.
+- Improved build times by 300% while reducing app size by 30% through dependency optimization.
+
+### [Pivotal Labs](https://pivotal.io/labs) — Senior Software Engineer
+November 2015–May 2017
+
+Worked with designers, product managers, engineers, and client stakeholders to ship production software using Lean and Extreme Programming practices.
+
+- Delivered broadcast-to-streaming pipeline management system for ABC using React, Java, and Spring.
+- Built streaming product features with machine-learning recommendations for video discovery.
+- Redesigned meal subscription workflow for FreshRealm, reducing checkout abandonment by 40%.
+- Launched Fair's automated car financing app with real-time loan approvals.
+- Modernized AAA SoCal's customer-facing roadside assistance and membership product.
+
+### Earlier Experience
+
+- **ThinkALike** — Architected photo-sharing social network with real-time matching algorithm to surface unknown connections.
+- **Freelance** — Built MVPs for pre-funded startups under condensed timelines, including location-sharing and music discovery products.
+- **Gray's College Enterprises** — Designed commerce and operations systems for textbook retail/wholesale, including Amazon marketplace pricing optimization, campus requirement scraping, inventory management, and remote purchasing workflows.
+
+### Selected Open Source / Technical Signals
+
+- Open source contributions to [ReSwift](https://github.com/ReSwift/ReSwift/commits?author=tkersey), [Homebrew](https://github.com/Homebrew/homebrew-core/commits?author=tkersey), and the [`isbn` RubyGem](https://rubygems.org/gems/isbn/versions/1.4.1).
+- GitHub user since February 2008.


### PR DESCRIPTION
This adds a DeployCo-targeted Forward Deployed / Agentic Systems Engineering resume draft.

Focus areas:
- Repositions Tim as a principal forward-deployed / agentic systems engineer rather than a mobile specialist.
- Mirrors the DeployCo FDE role requirements: ambiguous customer deployments, 0→1 reusable primitives, player-coach leadership, production AI workflows, and JavaScript/Python/full-stack credibility.
- Adds marketplace and commerce context, including eBay, Grailed, and Gray's.

Important follow-up before sending to DeployCo:
- Expand the eBay line with exact role/client context, dates, team size, stack, customer problem, and measurable outcome.
- Add any concrete DeployCo-relevant metrics around AI assistant deployment, prompt quality improvement, travel/customer-facing delivery, or enterprise stakeholder impact.